### PR TITLE
update ca-certificates package for Bugsnag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:edge
 RUN apk --update add ruby ruby-dev ruby-bundler && \
     rm -fr /usr/share/ri
 
+RUN apk --update add ca-certificates
+
 COPY files /
 
 CMD ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:edge
 
-RUN apk --update add ruby ruby-dev ruby-bundler && \
-    rm -fr /usr/share/ri
-
-RUN apk --update add ca-certificates
+RUN apk --update add \
+  ca-certificates \
+  ruby \
+  ruby-bundler \
+  ruby-dev && \
+  rm -fr /usr/share/ri
 
 COPY files /
 


### PR DESCRIPTION
Bugsnag was unable to connect to its server because ca-certificates was not up to date:

``` rb
core@cc-core02 ~ $ docker exec -it 5e8c126d2b65 sh
/usr/src/app # exec bundle exec irb -Ilib -r cc/wally
irb(main):001:0> Bugsnag
=> Bugsnag
irb(main):002:0> Bugsnag.notify(RuntimeError.new("ohai"))
=> #<Bugsnag::Notification:0x007fd8f5341a40 @configuration=#<Bugsnag::Configuration:0x007fd8f5281970 @mutex=#<Mutex:0x007fd8f5281948>, @auto_notify=true, @use_ssl=true, @send_environment=false, @send_code=true, @params_filters=#<Set: {/authorization/i, /cookie/i, /password/i, /secret/i, "rack.request.form_vars"}>, @ignore_classes=#<Set: {"ActiveRecord::RecordNotFound", "ActionController::RoutingError", "ActionController::InvalidAuthenticityToken", "CGI::Session::CookieStore::TamperedWithCookie", "ActionController::UnknownAction", "AbstractController::ActionNotFound", "Mongoid::Errors::DocumentNotFound", "SystemExit", "SignalException"}>, @ignore_user_agents=#<Set: {}>, @endpoint="notify.bugsnag.com", @hostname="5e8c126d2b65", @delivery_method=:thread_queue, @api_key="91cff0ba596990c7950bcf0f2f49d525", @logger=#<Logger:0x007fd8f5281510 @progname=nil, @level=2, @default_formatter=#<Logger::Formatter:0x007fd8f52814c0 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x007fd8f5281470 @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mutex=#<Logger::LogDevice::LogDeviceMutex:0x007fd8f5281448 @mon_owner=nil, @mon_count=0, @mon_mutex=#<Mutex:0x007fd8f52813f8>>>>, @internal_middleware=#<Bugsnag::MiddlewareStack:0x007fd8f52813d0 @middlewares=[], @disabled_middleware=[], @mutex=#<Mutex:0x007fd8f5281330>>, @middleware=#<Bugsnag::MiddlewareStack:0x007fd8f5281308 @middlewares=[Bugsnag::Middleware::Callbacks], @disabled_middleware=[], @mutex=#<Mutex:0x007fd8f5281290>>, @release_stage="production", @project_root="/usr/src/app">, @overrides={}, @request_data=nil, @meta_data={}, @user={}, @should_ignore=false, @exceptions=[#<RuntimeError: ohai>], @api_key="91cff0ba596990c7950bcf0f2f49d525">
irb(main):003:0> W, [2015-06-17T14:44:06.504672 #54]  WARN -- : ** [Bugsnag] Notification to https://notify.bugsnag.com failed, #<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed>
W, [2015-06-17T14:44:06.504816 #54]  WARN -- : ** [Bugsnag] ["/usr/lib/ruby/2.2.0/net/http.rb:923:in `connect'", "/usr/lib/ruby/2.2.0/net/http.rb:923:in `block in connect'", "/usr/lib/ruby/2.2.0/timeout.rb:74:in `timeout'", "/usr/lib/ruby/2.2.0/net/http.rb:923:in `connect'", "/usr/lib/ruby/2.2.0/net/http.rb:863:in `do_start'", "/usr/lib/ruby/2.2.0/net/http.rb:852:in `start'", "/usr/lib/ruby/2.2.0/net/http.rb:1375:in `request'", "/usr/lib/ruby/gems/2.2.0/gems/bugsnag-2.8.7/lib/bugsnag/delivery/synchronous.rb:40:in `request'", "/usr/lib/ruby/gems/2.2.0/gems/bugsnag-2.8.7/lib/bugsnag/delivery/synchronous.rb:12:in `deliver'", "/usr/lib/ruby/gems/2.2.0/gems/bugsnag-2.8.7/lib/bugsnag/delivery/thread_queue.rb:20:in `block in deliver'", "/usr/lib/ruby/gems/2.2.0/gems/bugsnag-2.8.7/lib/bugsnag/delivery/thread_queue.rb:37:in `call'", "/usr/lib/ruby/gems/2.2.0/gems/bugsnag-2.8.7/lib/bugsnag/delivery/thread_queue.rb:37:in `block (2 levels) in start_once!'"]
```

This will need to be tagged in the Docker registry and then all of the other `Dockerfile`s updated accordingly.
