### PR TITLE
Revert back to edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@ RUN apk --update add \
   rm -fr /usr/share/ri
 
 # Ensure we get v1.0.2h
-RUN apk --upgrade add openssl
+RUN apk \
+  --upgrade \
+  --update-cache \
+  --repository http://dl-cdn.alpinelinux.org/alpine/v3.3/main \
+  add openssl
 
 COPY files /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:edge
 
 RUN apk --update add \
   ca-certificates \


### PR DESCRIPTION
Something about the v3.3 ruby installation is not right and we find require
errors on basic packages like io-console and bigdecimal in downstream projects.
This is likely why this is still using edge.

Down the line, the real fix will probably be to avoid this image entirely and
use the official alpine-based ruby images. That has been deferred for now.

/cc @codeclimate/review

So... Keep it edge, but install v3.3's openssl.
